### PR TITLE
workaround for serial read timeout?

### DIFF
--- a/src/fancy_cui.c
+++ b/src/fancy_cui.c
@@ -147,6 +147,7 @@ static void main_loop(HANDLE serial_hdl)
 	OVERLAPPED ov = {0};
 	unsigned char ser_in;
 	unsigned char std_in;
+	DWORD rlen;
 
 	stdin_hdl = GetStdHandle(STD_INPUT_HANDLE);
 	if (stdin_hdl == INVALID_HANDLE_VALUE) {
@@ -181,7 +182,12 @@ static void main_loop(HANDLE serial_hdl)
 				goto out;
 			break;
 		case WAIT_OBJECT_0 + 1:
-			printf("\t\t\t\tgot data on serial: 0x%02x\n", ser_in);
+			/* NOTE: enters here without serial data
+			 * once in a sec. don't know why. */
+			GetOverlappedResult(serial_hdl, &ov, &rlen, FALSE);
+			if (rlen > 0)
+				printf("\t\t\t\tgot data on serial: 0x%02x\n",
+				       ser_in);
 
 			/* Next try */
 			ResetEvent(ov.hEvent);

--- a/src/fancy_cui.c
+++ b/src/fancy_cui.c
@@ -182,12 +182,12 @@ static void main_loop(HANDLE serial_hdl)
 				goto out;
 			break;
 		case WAIT_OBJECT_0 + 1:
-			/* NOTE: enters here without serial data
-			 * once in a sec. don't know why. */
 			GetOverlappedResult(serial_hdl, &ov, &rlen, FALSE);
 			if (rlen > 0)
 				printf("\t\t\t\tgot data on serial: 0x%02x\n",
 				       ser_in);
+			else
+				printf("serial read timeout\n");
 
 			/* Next try */
 			ResetEvent(ov.hEvent);

--- a/src/serial_util.c
+++ b/src/serial_util.c
@@ -63,6 +63,7 @@ static void serial_setup_dcb(HANDLE handle, const DCB *dcb_saved)
 HANDLE serial_open(const char *fn, DCB *dcb_saved)
 {
 	HANDLE handle;
+	COMMTIMEOUTS to;
 
 	handle = CreateFile(fn, GENERIC_READ | GENERIC_WRITE, 0, NULL,
 			    OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
@@ -72,6 +73,13 @@ HANDLE serial_open(const char *fn, DCB *dcb_saved)
 
 	GetCommState(handle, dcb_saved);
 	serial_setup_dcb(handle, dcb_saved);
+
+	/* setup timeout */
+	GetCommTimeouts(handle, &to);
+	to.ReadIntervalTimeout = 0;
+	to.ReadTotalTimeoutConstant = 0;
+	SetCommTimeouts(handle, &to);
+
 	return handle;
 }
 


### PR DESCRIPTION
※追記あり

うちの環境(WinXP, VC10, PC-OP-RS1)だとなぜか
serialのread requestが１秒毎にタイムアウトしているような動きをして
リードしてないのにov.hEventが発生するので、
１秒おきに前にリードしたデータが表示されてしまいます。

なのでGetOverlappedResult()を使ってread sizeを確認する処理を入れました。
よかったらマージしてやってください。

＜追記＞
SetCommTimeouts() 追加したらタイムアウトなくなりました。
